### PR TITLE
Fix typo in TestEnvironment method name generateUniqueIdentifier

### DIFF
--- a/src/main/java/org/apache/fineract/cn/test/env/TestEnvironment.java
+++ b/src/main/java/org/apache/fineract/cn/test/env/TestEnvironment.java
@@ -131,12 +131,12 @@ public final class TestEnvironment extends ExternalResource {
     return this;
   }
 
-  public String generateUniqueIdentifer(final String prefix) {
-    return generateUniqueIdentifer(prefix, 1);
+  public String generateUniqueIdentifier(final String prefix) {
+    return generateUniqueIdentifier(prefix, 1);
   }
 
   //prefix followed by a positive number.
-  public String generateUniqueIdentifer(final String prefix, final int minimumDigitCount) {
+  public String generateUniqueIdentifier(final String prefix, final int minimumDigitCount) {
     uniquenessSuffix++;
     final String format = String.format("%%0%dd", minimumDigitCount);
     return prefix + String.format(format, uniquenessSuffix);

--- a/src/test/java/org/apache/fineract/cn/test/env/TestEnvironmentTest.java
+++ b/src/test/java/org/apache/fineract/cn/test/env/TestEnvironmentTest.java
@@ -42,8 +42,8 @@ public class TestEnvironmentTest {
   @Test
   public void shouldGenerateUniqueId() {
     final TestEnvironment testEnvironment = new TestEnvironment("fineract-cn-core");
-    final String uniqueId = testEnvironment.generateUniqueIdentifer(UNIQUE_ID_PREFIX);
-    final String uniqueId2 = testEnvironment.generateUniqueIdentifer(UNIQUE_ID_PREFIX);
+    final String uniqueId = testEnvironment.generateUniqueIdentifier(UNIQUE_ID_PREFIX);
+    final String uniqueId2 = testEnvironment.generateUniqueIdentifier(UNIQUE_ID_PREFIX);
     Assert.assertNotEquals(uniqueId, uniqueId2);
     Assert.assertTrue(uniqueId.startsWith(UNIQUE_ID_PREFIX));
     Assert.assertTrue(uniqueId2.startsWith(UNIQUE_ID_PREFIX));
@@ -52,7 +52,7 @@ public class TestEnvironmentTest {
   @Test
   public void shouldGenerateZeroBufferedUniqueId() {
     final TestEnvironment testEnvironment = new TestEnvironment("fineract-cn-core");
-    final String uniqueId = testEnvironment.generateUniqueIdentifer(UNIQUE_ID_PREFIX, 5);
+    final String uniqueId = testEnvironment.generateUniqueIdentifier(UNIQUE_ID_PREFIX, 5);
     Assert.assertTrue(uniqueId.startsWith(UNIQUE_ID_PREFIX));
     Assert.assertEquals(uniqueId.length() - UNIQUE_ID_PREFIX.length(), 5);
   }


### PR DESCRIPTION
Minor : Fix typo in TestEnvironment method name generateUniqueIdentifier()