### PR TITLE
Fix an issue when PostgreSQLInitializer is not creating default tenant in test

### DIFF
--- a/src/main/java/org/apache/fineract/cn/test/fixture/postgresql/PostgreSQLInitializer.java
+++ b/src/main/java/org/apache/fineract/cn/test/fixture/postgresql/PostgreSQLInitializer.java
@@ -161,8 +161,8 @@ public final class PostgreSQLInitializer extends DataStoreTenantInitializer {
         statement.execute("CREATE DATABASE " + identifier);
         // insert tenant connection info in management table
         try (final ResultSet resultSet = statement.executeQuery("SELECT * FROM tenants WHERE identifier = '" + identifier + "'")) {
-          if (resultSet.next()
-              && resultSet.getInt(1) == 0) {
+          if (!resultSet.next()
+              || (resultSet.next() && resultSet.getInt(1) == 0)) {
             final PostgreSQLTenant postgreSQLTenant = new PostgreSQLTenant();
             postgreSQLTenant.setIdentifier(identifier);
             postgreSQLTenant.setDriverClass(System.getProperty(TestEnvironment.POSTGRESQL_DRIVER_CLASS_PROPERTY));


### PR DESCRIPTION
Fix an issue when PostgreSQLInitializer is not creating default tenan…t database. The similar check is not present in CassandraSQLInitializer.